### PR TITLE
Added a Npmignore 

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json


### PR DESCRIPTION
This pr aims to remove the Node Modules and package-lock.json files/folders from being downloaded when installing this package because it seems to be overriding the current installation of discord.js

For e.g:
If I have `v13.1.0` the typings from the `v12.5.3` that this package installed gets overridden and causes errors