### PR TITLE
Update discord.js to be a peerDependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "The first package which combines Sharding Manager & Internal Sharding to save a lot of ressources",
   "main": "index.js",
   "types": "./typings.d.ts",
-  "dependencies": {
-    "discord.js": "^12.5.3"
+  "peerDependencies": {
+    "discord.js": "^13.x"
   },
   "script": {
     "generate-docs": "node_modules/.bin/jsdoc -c ./.jsdoc.conf.json"

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -119,11 +119,11 @@ declare module 'discord-hybrid-sharding' {
     public once(event: "debug", listener: (message: string) => void): this;
   }
   export class data{
-    public SHARD_LIST: number[], 
-    public TOTAL_SHARDS: number, 
-    public CLUSTER_COUNT: number, 
-    public CLUSTER: number, 
-    public CLUSTER_MANAGER_MODE: ClusterManagerMode
+    public SHARD_LIST: number[];
+    public TOTAL_SHARDS: number;
+    public CLUSTER_COUNT: number;
+    public CLUSTER: number;
+    public CLUSTER_MANAGER_MODE: ClusterManagerMode;
   }
     
     

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -18,6 +18,7 @@ declare module 'discord-hybrid-sharding' {
     public process: ChildProcess | null;
     public ready: boolean;
     public worker: any | null;
+    public data: data;
     public eval(script: string): Promise<any>;
     public eval<T>(fn: (client: client) => T): Promise<T[]>;
     public fetchClientValue(prop: string): Promise<any>;
@@ -118,14 +119,7 @@ declare module 'discord-hybrid-sharding' {
     public once(event: 'clusterCreate', listener: (cluster: Cluster) => void): this;
     public once(event: "debug", listener: (message: string) => void): this;
   }
-  export class data{
-    public SHARD_LIST: number[];
-    public TOTAL_SHARDS: number;
-    public CLUSTER_COUNT: number;
-    public CLUSTER: number;
-    public CLUSTER_MANAGER_MODE: ClusterManagerMode;
-  }
-    
+  export const data: data;
     
   type ClusterManagerMode = 'process' | 'worker';
   type client = DJsClient;


### PR DESCRIPTION
As the plugin is only extending discord.js, we should have it as a peer dependency to avoid package version conflicts.

I've also gone ahead and bumped the version to be above `v13`, the latest for d.js, as `^12.5.3` only lets the major version `12` through. (see https://semver.npmjs.com/)

Also fixes typing issues:
    - The error `';' expected`, in the data class of the typings.
    - Changes `export class data` to `export const data` to work with the docs.