### PR TITLE
EvalOnCluster Shard Implementation

### DIFF
--- a/src/ClusterClient.js
+++ b/src/ClusterClient.js
@@ -258,7 +258,7 @@ class ClusterClient {
    */
   evalOnCluster(script, options = {}) {
     return new Promise((resolve, reject) => {
-      if (!options.hasOwnProperty('cluster')) reject('TARGET CLUSTER HAS NOT BEEN PROVIDED');
+      if (!options.hasOwnProperty('cluster') && !options.hasOwnProperty('shard')) reject('TARGET CLUSTER HAS NOT BEEN PROVIDED');
       script = typeof script === 'function' ? `(${script})(this)` : script;
       const nonce = Date.now().toString(36) + Math.random().toString(36);
       this._nonce.set(nonce, { resolve, reject });
@@ -269,7 +269,7 @@ class ClusterClient {
           this._nonce.delete(nonce);
         }
       }, options.timeout);
-      this.send({ _sClusterEval: script, nonce, timeout: options.timeout, cluster: options.cluster });
+      this.send({ _sClusterEval: script, nonce, ...options });
     })
   }
 

--- a/src/ClusterManager.js
+++ b/src/ClusterManager.js
@@ -136,7 +136,7 @@ class ClusterManager extends EventEmitter {
     * A collection of all clusters the manager spawned
     * @type {Collection<number, Cluster>}
     */
-    this.clusters = new Map();
+    this.clusters = new Discord.Collection();
     this.shardclusterlist = null;
     process.env.SHARD_LIST = undefined;
     process.env.TOTAL_SHARDS = this.totalShards;
@@ -349,6 +349,9 @@ class ClusterManager extends EventEmitter {
   * @private
   */
   evalOnCluster(script, options) {
+    if(options.hasOwnProperty('shard')){
+        options.cluster = parseInt(Object.entries(Object.assign({}, this.shardclusterlist)).find(i => i[1].includes(options.shard))?.[0]);
+    }
     const cluster = this.clusters.get(options.cluster);
     if (!cluster) return Promise.reject(new Error('CLUSTER_DOES_NOT_EXIST', options.cluster));
     if (!cluster.process && !cluster.worker) return Promise.reject(new Error('CLUSTERING_NO_CHILD_EXISTS', cluster.id));

--- a/src/ClusterManager.js
+++ b/src/ClusterManager.js
@@ -350,7 +350,7 @@ class ClusterManager extends EventEmitter {
   */
   evalOnCluster(script, options) {
     if(options.hasOwnProperty('shard')){
-        options.cluster = parseInt(Object.entries(Object.assign({}, this.shardclusterlist)).find(i => i[1].includes(options.shard))?.[0]);
+        options.cluster = parseInt(Object.entries(Object.assign({}, this.shardclusterlist)).find(i => i[1].includes(options.shard)) ? i[1].includes(options.shard))[0]) : 0;
     }
     const cluster = this.clusters.get(options.cluster);
     if (!cluster) return Promise.reject(new Error('CLUSTER_DOES_NOT_EXIST', options.cluster));


### PR DESCRIPTION
With this, you can Eval on a cluster in which a shard is present. Useful when you can find the shardId of a server using the formula 
`Number(BigInt(guildId) >> 22n) % process.env.TOTAL_SHARDS`
```js
client.cluster.evalOnCluster(`your code here`,{shard:x});
```
Also changes from Map to Discord Collection