### PR TITLE
Fixed typo in Heartbeat debug logs

### DIFF
--- a/src/Cluster.js
+++ b/src/Cluster.js
@@ -535,7 +535,7 @@ class Cluster extends EventEmitter {
               if(this._restarts.current > this.manager.keepAlive.maxClusterRestarts) return;
             }
           }
-          this.manager._debug(`[Heartbeat_MISSING] Attempting respawn | To much hearbeats were missing.`, this.id);
+          this.manager._debug(`[Heartbeat_MISSING] Attempting respawn | To much heartbeats were missing.`, this.id);
           this._cleanupHearbeat()
           this.respawn()
         }


### PR DESCRIPTION
This pr aims at fixing a spelling typo in the Cluster debug logs