### PR TITLE
fix(types): Shards per cluster cannot be automatically set.

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -90,7 +90,7 @@ declare module 'discord-hybrid-sharding' {
       options?: {
         totalShards?: number | 'auto';
         totalClusters?: number | 'auto';
-        shardsPerClusters?: number | 'auto';
+        shardsPerClusters?: number;
         shardList?: number[] | 'auto';
         mode?: ClusterManagerMode;
         respawn?: boolean;

--- a/typings.d.ts
+++ b/typings.d.ts
@@ -115,6 +115,7 @@ declare module 'discord-hybrid-sharding' {
     public shardsPerClusters: number | 'auto';
     public totalShards: number | 'auto';
     public shardList: number[] | 'auto';
+    public clusterList: number[]
     public keepAlive: keepAliveOptions;
     public broadcast(message: any): Promise<Cluster[]>;
     public broadcastEval(script: string): Promise<any[]>;


### PR DESCRIPTION
Settings shardsPerCluster to "auto" gives an error, this fixes the typings which state "auto" is a valid input.
![image](https://user-images.githubusercontent.com/35779365/147839364-18d56b18-2096-490b-8a36-69716d7c7c97.png)
