### PR TITLE
fix: error TS1070: 'public' modifier cannot appear on a type member

### DIFF
--- a/typings.d.ts
+++ b/typings.d.ts
@@ -231,7 +231,7 @@ declare module 'discord-hybrid-sharding' {
         timeout?: number;
     }
 
-    export interface Queue {
+    export class Queue {
         options: {
             auto?: boolean;
             timeout?: number;


### PR DESCRIPTION
Fix #37 