### PR TITLE
Fix a pretty critical bug in broadcastEval

### DIFF
--- a/src/Core/ClusterManager.ts
+++ b/src/Core/ClusterManager.ts
@@ -389,7 +389,7 @@ export class ClusterManager extends EventEmitter {
         if (options.guildId) {
             options.shard = shardIdForGuildId(options.guildId, this.totalShards);
         }
-        if (options.shard) {
+        if (options.shard !== undefined && options.shard !== null) {
             if (typeof options.shard === 'number') {
                 if (options.shard < 0) throw new RangeError('SHARD_ID_OUT_OF_RANGE');
             }


### PR DESCRIPTION
If the shardId calculated from guildId is 0, it evals on every single cluster