### PR TITLE
fix(recluster): clear MAINTENANCE env after gracefulSwitch so respawn…

### DIFF
--- a/dist/Plugins/ReCluster.js
+++ b/dist/Plugins/ReCluster.js
@@ -156,7 +156,15 @@ class ReClusterManager {
         }
         newClusters.clear();
         this.onProgress = false;
-        process.env.MAINTENANCE = undefined;
+        // [fork fix] Original `process.env.MAINTENANCE = undefined` coerces to the string
+        // "undefined" and leaves MAINTENANCE='recluster' baked into every Cluster.env
+        // (snapshotted at construction, reused on every respawn). A later death/heartbeat
+        // respawn then boots the child in maintenance mode, so its `ready` event never fires
+        // and handlers never load. Clear the flag on the manager and every live cluster.
+        for (const cluster of this.manager.clusters.values()) {
+            delete cluster.env.MAINTENANCE;
+        }
+        delete process.env.MAINTENANCE;
         this.manager._debug('[↻][ReClustering] Finished ReClustering');
         return { success: true };
     }

--- a/src/Plugins/ReCluster.ts
+++ b/src/Plugins/ReCluster.ts
@@ -198,7 +198,15 @@ export class ReClusterManager {
 
         newClusters.clear();
         this.onProgress = false;
-        process.env.MAINTENANCE = undefined;
+        // [fork fix] Original `process.env.MAINTENANCE = undefined` coerces to the string
+        // "undefined" and leaves MAINTENANCE='recluster' baked into every Cluster.env
+        // (snapshotted at construction, reused on every respawn). A later death/heartbeat
+        // respawn then boots the child in maintenance mode, so its `ready` event never fires
+        // and handlers never load. Clear the flag on the manager and every live cluster.
+        for (const cluster of this.manager.clusters.values()) {
+            delete cluster.env.MAINTENANCE;
+        }
+        delete process.env.MAINTENANCE;
         this.manager._debug('[↻][ReClustering] Finished ReClustering');
         return { success: true };
     }


### PR DESCRIPTION
ReClusterManager set process.env.MAINTENANCE = undefined (coerces to the string "undefined") and left MAINTENANCE='recluster' baked into every Cluster.env, which is snapshotted from process.env at construction and reused verbatim on every respawn. After a recluster, any later death/heartbeat respawn reused that env and booted the child in maintenance mode, so ClusterClient never fired its 'ready' event and downstream handlers never loaded — the cluster was stuck in maintenance with commands dead until a full restart.

Delete MAINTENANCE from the manager env and from every live Cluster.env once reclustering finishes.